### PR TITLE
Update secret_token.rb, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Penpal Gladiators
 
-### Code Climate GPA
+[Deployed App](https://penpal-gladiators.herokuapp.com/)
+
+[Pivotal Tracker Project](https://www.pivotaltracker.com/n/projects/1282960)
+
+#### Code Climate GPA
 
 [![Code Climate](https://codeclimate.com/github/Fong-/CS169-PenPal-Gladiators/badges/gpa.svg)](https://codeclimate.com/github/Fong-/CS169-PenPal-Gladiators)
 
-### Code Climate Test Coverage
+#### Code Climate Test Coverage
 
 [![Test Coverage](https://codeclimate.com/github/Fong-/CS169-PenPal-Gladiators/badges/coverage.svg)](https://codeclimate.com/github/Fong-/CS169-PenPal-Gladiators)
 
-### TravisCI
+#### TravisCI
 
 [![Build Status](https://travis-ci.org/Fong-/CS169-PenPal-Gladiators.svg?branch=master)](https://travis-ci.org/Fong-/CS169-PenPal-Gladiators)

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,1 +1,5 @@
-CS169PenpalGladiators::Application.config.secret_token = "14f28f761dd98cc0abb75c9f3416619a988bb25b0eaa388d6cf1ddb92d3b9d125a3f7ece878d35c0639c2b61b12d2ea51ce79bcd3530eb652f6d5691e76009d9"
+CS169PenpalGladiators::Application.config.secret_token = if Rails.env.development? or Rails.env.test?
+  ('x' * 30)
+else
+  ENV['SECRET_TOKEN']
+end


### PR DESCRIPTION
Change `secret_token` in `secret_token.rb`.  If in development or test, use a string of 'x' repeating 30 times to meet minimum length requirements.  If in production, the `SECRET_TOKEN` environment variable is set on Heroku to be 128 random hex chars generated from /dev/random.  

Also update README to include links to PT and Heroku.  
