### PR TITLE
Sidebar conversations

### DIFF
--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -6,6 +6,12 @@
                     <a class="gladiator-heading">{{gladiatorNameById[gladiatorId]}}</a>
                     <span class="{{expandButtonClass(gladiatorId)}} click-to-expand"></span>
                 </div>
+
+                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="">
+                    <a class="conversation-start">Start a new converstation</a>
+                    <span class="btn glyphicon glyphicon-plus"></span>
+                </div>
+
                 <div class="conversation-preview" ng-repeat="conversation in conversationsByUserId[gladiatorId]" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationPreviewClicked(conversation.id)">
                     <div class="conversation-heading">
                         <div class="conversation-actions">

--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -7,7 +7,7 @@
                     <span class="{{expandButtonClass(gladiatorId)}} click-to-expand"></span>
                 </div>
 
-                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="">
+                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationStartClicked(gladiatorId)">
                     <a class="conversation-start">Start a new converstation</a>
                     <span class="btn glyphicon glyphicon-plus"></span>
                 </div>

--- a/app/assets/javascripts/shared/api.coffee
+++ b/app/assets/javascripts/shared/api.coffee
@@ -55,6 +55,10 @@ angular.module("SharedServices").service("API", ["$http", "$cookieStore", ($http
         request = generateRequest("conversation/#{id}")
         $http.get(request, { params: { token: getToken() } })
 
+    this.createConversationByUser = (id) ->
+        request = generateRequest("conversation/create/#{id}")
+        $http.post(request, { token: getToken() })
+
     this.createPostByConversationId = (id, text) ->
         request = generateRequest("post/create/#{id}")
         $http.post(request, { text: text, token: getToken() })

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -242,7 +242,7 @@ p {
 
     li {
         padding: 5px 5px 0px 5px;
-        border-bottom: 1px solid #D4D4D4;
+        border-bottom: 1px solid #E1E1E1;
 
         @media(max-width: 768px) {
             &:last-child {
@@ -253,7 +253,7 @@ p {
         .conversation-start-container {
             padding: 10px;
             padding-left: 20px;
-            border-top: 1px dotted #D4D4D4;
+            border-top: 1px dotted #E1E1E1;
 
             &:hover {
                 background-color: #F8F8F8;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -252,7 +252,7 @@ p {
 
         .conversation-start-container {
             padding: 10px;
-            padding-left: 20px;
+            padding-left: 25px;
             border-top: 1px dotted #E1E1E1;
 
             &:hover {
@@ -274,7 +274,7 @@ p {
 
         .conversation-preview {
             padding: 10px;
-            padding-left: 20px;
+            padding-left: 25px;
             font-size: 13px;
             background-color: #ffffff;
             border-top: 1px dotted #e1e1e1;
@@ -294,6 +294,7 @@ p {
 
                 .conversation-actions {
                     float: right;
+                    margin-left: 5px;
 
                     .conversation-advance {
                         font-size: 10px;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -250,6 +250,28 @@ p {
             }
         }
 
+        .conversation-start-container {
+            padding: 10px;
+            padding-left: 20px;
+            border-top: 1px dotted #D4D4D4;
+
+            &:hover {
+                background-color: #F8F8F8;
+            }
+
+            .conversation-start {
+                padding: 0;
+                font-size: 16px;
+                color: #888;
+            }
+
+            .glyphicon-plus {
+                float: right;
+                font-size: 10px;
+                padding: 6px 8px;
+            }
+        }
+
         .conversation-preview {
             padding: 10px;
             padding-left: 20px;

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -16,7 +16,7 @@ class ConversationsController < ApplicationController
             arenas = Arena.for_users(user, other_user)
 
             if arenas.length == 0
-                render_error(:resource_not_found, :resource => :arena)
+                render_error(:resource_not_found, :resource => :arena) and return
             end
 
             arena = arenas[0]

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -4,7 +4,26 @@ class ConversationsController < ApplicationController
         if conversation.present?
             render :json => conversation.response_object
         else
-            render :json => { :error => "No such conversation." }
+            render_error(:resource_not_found)
+        end
+    end
+
+    def create
+        user = @token_results[:user]
+        other_user = User.find_by_id(params[:user_id])
+
+        if other_user.present?
+            arenas = Arena.for_users(user, other_user)
+
+            if arenas.length == 0
+                render_error(:resource_not_found, :resource => :arena)
+            end
+
+            arena = arenas[0]
+            conversation = arena.conversations.create :title => "Untitled Conversation"
+            render :json => { :id => conversation.id }
+        else
+            render_error(:resource_not_found, :resource => :other_user)
         end
     end
 end

--- a/app/models/arena.rb
+++ b/app/models/arena.rb
@@ -4,6 +4,10 @@ class Arena < ActiveRecord::Base
     has_many :conversations
     attr_accessible :user1, :user2
 
+    scope :for_users, ->(user1, user2) do
+        where("(user1_id = :user1 AND user2_id = :user2) OR (user1_id = :user2 AND user2_id = :user1)", :user1 => user1, :user2 => user2)
+    end
+
     def response_object
         conversations_response = []
         conversations.each do |conversation|

--- a/app/util/error_handler.rb
+++ b/app/util/error_handler.rb
@@ -19,8 +19,8 @@ module ErrorHandler
         :resource_not_found => 404
     }
 
-    def render_error(error)
-        render :json => { :error => ERROR[error] }, :status => ERROR_CODE[error]
+    def render_error(error, args = {})
+        render :json => { :error => ERROR[error] }.merge(args), :status => ERROR_CODE[error]
     end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ CS169PenpalGladiators::Application.routes.draw do
     post "/api/v1/user/:id/profile" => "users#post_profile_info_by_id"
     get "/api/v1/arenas/:user_id" => "arenas#get_by_user_id"
     get "/api/v1/conversation/:id" => "conversations#get_by_id"
+    post "/api/v1/conversation/create/:user_id" => "conversations#create"
     post "/api/v1/post/create/:conversation_id" => "posts#create"
     post "/api/v1/post/edit/:post_id" => "posts#edit"
     # Public routes


### PR DESCRIPTION
Added button for starting conversations, added the backend to accommodate, and very very slight CSS tweaks to make things look cool.

CSS Changes:
- Adjusted padding more to make affordance between sections more clear.
- Added margins to the conversation actions container for readability in edge cases.
- Added conversation start container which holds the start control.

Backend Changes:
- Added a route to create conversations.
- Added a scope to the arena model to easily get the arena for two users. Use with `Arena.for_users(user1, user2)`

Frontend Changes:
- Added a handler to call the new api call in both `sidebar.coffee` and `api.coffee`.
- Adjusted sidebar to automatically reload whenever a new conversation is created.

NOTE: Noted that there is currently no way to change conversation title. Either that should be offloaded to the conversation page, or made on conversation creation. I personally think offloading to the conversation page makes the most sense. If that is the case, a service will need to be exposed to reload the sidebar.
