### PR TITLE
Sidebar matching

### DIFF
--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -6,6 +6,12 @@
                     <a class="gladiator-heading">{{gladiatorNameById[gladiatorId]}}</a>
                     <span class="{{expandButtonClass(gladiatorId)}} click-to-expand"></span>
                 </div>
+
+                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="">
+                    <a class="conversation-start">Start a new converstation</a>
+                    <span class="btn glyphicon glyphicon-plus"></span>
+                </div>
+
                 <div class="conversation-preview" ng-repeat="conversation in conversationsByUserId[gladiatorId]" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationPreviewClicked(conversation.id)">
                     <div class="conversation-heading">
                         <div class="conversation-actions">

--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -1,6 +1,8 @@
 <div class="nav-side-menu" ng-controller="SidebarController">
     <div class="menu-list">
         <ul class="menu-content">
+            <div ui-view="sidebar-matching" class="sidebar-matching-container"></div>
+
             <li ng-repeat="gladiatorId in gladiatorIds">
                 <div class="gladiator-heading-container" ng-click="toggleGladiatorPanel(gladiatorId)">
                     <a class="gladiator-heading">{{gladiatorNameById[gladiatorId]}}</a>

--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -4,22 +4,22 @@
             <div ui-view="sidebar-matching" class="sidebar-matching-container"></div>
 
             <li ng-repeat="gladiatorId in gladiatorIds">
-                <div class="gladiator-heading-container" ng-click="toggleGladiatorPanel(gladiatorId)">
-                    <a class="gladiator-heading">{{gladiatorNameById[gladiatorId]}}</a>
+                <div class="gladiator-heading-container menu-item" ng-click="toggleGladiatorPanel(gladiatorId)">
+                    <a class="gladiator-heading heading">{{gladiatorNameById[gladiatorId]}}</a>
                     <span class="{{expandButtonClass(gladiatorId)}} click-to-expand"></span>
                 </div>
 
-                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationStartClicked(gladiatorId)">
-                    <a class="conversation-start">Start a new converstation</a>
+                <div class="conversation-start-container menu-item subitem" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationStartClicked(gladiatorId)">
+                    <a class="conversation-start heading">Start a new converstation</a>
                     <span class="btn glyphicon glyphicon-plus"></span>
                 </div>
 
-                <div class="conversation-preview" ng-repeat="conversation in conversationsByUserId[gladiatorId]" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationPreviewClicked(conversation.id)">
+                <div class="conversation-preview menu-item subitem" ng-repeat="conversation in conversationsByUserId[gladiatorId]" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationPreviewClicked(conversation.id)">
                     <div class="conversation-heading">
                         <div class="conversation-actions">
                             <div class="conversation-advance glyphicon glyphicon-arrow-right btn" ng-click="conversationPreviewClicked(conversation.id)"></div>
                         </div>
-                        <p class="conversation-title">{{conversation.title}}</p>
+                        <p class="conversation-title heading">{{conversation.title}}</p>
                     </div>
                     <p class="conversation-time">{{conversation.time}}</p>
                     <p class="conversation-text">{{conversation.post_preview_text}}</p>

--- a/app/assets/html/sidebar.html
+++ b/app/assets/html/sidebar.html
@@ -7,7 +7,7 @@
                     <span class="{{expandButtonClass(gladiatorId)}} click-to-expand"></span>
                 </div>
 
-                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="">
+                <div class="conversation-start-container" ng-show="arenaStateByUserId[gladiatorId]" ng-click="conversationStartClicked(gladiatorId)">
                     <a class="conversation-start">Start a new converstation</a>
                     <span class="btn glyphicon glyphicon-plus"></span>
                 </div>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -6,7 +6,7 @@
 
     <div class="user menu-item subitem" ng-repeat="match in matches" ng-show="expanded['matches']" ng-click="goToProfile(match.user.id)">
         <a class="heading">{{match.user.username}}</a>
-        <span class="btn" ng-click="matchWith(match.user.id)">Match</span>
+        <span class="btn" ng-click="matchWith(match.user.id); $event.stopPropagation();">Match</span>
     </div>
 </li>
 
@@ -31,7 +31,7 @@
 
     <div class="user menu-item subitem" ng-repeat="user in incoming" ng-show="expanded['incoming']" ng-click="goToProfile(user.id)">
         <a class="heading">{{user.username}}</a>
-        <span class="btn" ng-click="reject(user.id)">Reject</span>
-        <span class="btn" ng-click="accept(user.id)">Accept</span>
+        <span class="btn" ng-click="reject(user.id); $event.stopPropagation();">Reject</span>
+        <span class="btn" ng-click="accept(user.id); $event.stopPropagation();">Accept</span>
     </div>
 </li>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -1,6 +1,6 @@
-<li class="matches-container">
+<li class="matches-container menu-item">
     <div class="matches-header-container" ng-click="toggle('matches')">
-        <a class="matches-header">My Matches</a>
+        <a class="matches-header heading">My Matches</a>
         <span ng-class="classes['matches']" class="click-to-expand"></span>
     </div>
 
@@ -9,9 +9,9 @@
     </div>
 </li>
 
-<li class="pending-matches-container">
+<li class="pending-matches-container menu-item">
     <div class="pending-matches-header-container" ng-click="toggle('pending')">
-        <a class="matches-header">Pending Matches</a>
+        <a class="pending-matches-header heading">Pending Matches</a>
         <span ng-class="classes['pending']" class="click-to-expand"></span>
     </div>
 
@@ -21,9 +21,9 @@
     </div>
 </li>
 
-<li class="incoming-matches-container">
+<li class="incoming-matches-container menu-item">
     <div class="incoming-matches-header-container" ng-click="toggle('incoming')">
-        <a class="matches-header">Incoming Matches</a>
+        <a class="incoming-matches-header heading">Incoming Matches</a>
         <span ng-class="classes['incoming']" class="click-to-expand"></span>
     </div>
 

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -6,7 +6,7 @@
 
     <div class="user menu-item subitem" ng-repeat="user in matches" ng-show="expanded['matches']" ng-click="goToProfile(user.id)">
         <a class="heading">{{user.name}}</a>
-        <span class="btn btn-primary" ng-click="matchWith(user.id)">Match</span>
+        <span class="btn" ng-click="matchWith(user.id)">Match</span>
     </div>
 </li>
 
@@ -19,6 +19,7 @@
 
     <div class="user menu-item subitem" ng-repeat="user in pending" ng-show="expanded['pending'] ">
         <a class="heading">{{user.name}}</a>
+        <span class="btn" ng-click="reject(user.id)">Reject</span>
     </div>
 </li>
 
@@ -31,5 +32,7 @@
 
     <div class="user menu-item subitem" ng-repeat="user in incoming" ng-show="expanded['incoming']">
         <a class="heading">{{user.name}}</a>
+        <span class="btn" ng-click="reject(user.id)">Reject</span>
+        <span class="btn" ng-click="accept(user.id)">Accept</span>
     </div>
 </li>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -4,9 +4,9 @@
         <span ng-class="classes['matches']" class="click-to-expand"></span>
     </div>
 
-    <div class="user menu-item subitem" ng-repeat="user in matches" ng-show="expanded['matches']" ng-click="goToProfile(user.id)">
-        <a class="heading">{{user.name}}</a>
-        <span class="btn" ng-click="matchWith(user.id)">Match</span>
+    <div class="user menu-item subitem" ng-repeat="match in matches" ng-show="expanded['matches']" ng-click="goToProfile(match.user.id)">
+        <a class="heading">{{match.user.username}}</a>
+        <span class="btn" ng-click="matchWith(match.user.id)">Match</span>
     </div>
 </li>
 
@@ -17,9 +17,8 @@
         <span ng-class="classes['pending']" class="click-to-expand"></span>
     </div>
 
-    <div class="user menu-item subitem" ng-repeat="user in pending" ng-show="expanded['pending'] ">
-        <a class="heading">{{user.name}}</a>
-        <span class="btn" ng-click="reject(user.id)">Reject</span>
+    <div class="user menu-item subitem" ng-repeat="user in pending" ng-show="expanded['pending']" ng-click="goToProfile(user.id)">
+        <a class="heading">{{user.username}}</a>
     </div>
 </li>
 
@@ -30,8 +29,8 @@
         <span ng-class="classes['incoming']" class="click-to-expand"></span>
     </div>
 
-    <div class="user menu-item subitem" ng-repeat="user in incoming" ng-show="expanded['incoming']">
-        <a class="heading">{{user.name}}</a>
+    <div class="user menu-item subitem" ng-repeat="user in incoming" ng-show="expanded['incoming']" ng-click="goToProfile(user.id)">
+        <a class="heading">{{user.username}}</a>
         <span class="btn" ng-click="reject(user.id)">Reject</span>
         <span class="btn" ng-click="accept(user.id)">Accept</span>
     </div>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -1,0 +1,34 @@
+<li class="matches-container">
+    <div class="matches-header-container" ng-click="toggle('matches')">
+        <a class="matches-header">My Matches</a>
+        <span ng-class="classes['matches']" class="click-to-expand"></span>
+    </div>
+
+    <div class="user" ng-repeat="user in matches" ng-show="expanded['matches']">
+        <p>{{user.name}}</p>
+    </div>
+</li>
+
+<li class="pending-matches-container">
+    <div class="pending-matches-header-container" ng-click="toggle('pending')">
+        <a class="matches-header">Pending Matches</a>
+        <span ng-class="classes['pending']" class="click-to-expand"></span>
+    </div>
+
+    <div class="user" ng-repeat="user in pending" ng-show="expanded['pending']">
+        <p>{{user.name}}</p>
+        <!-- Something for status -->
+    </div>
+</li>
+
+<li class="incoming-matches-container">
+    <div class="incoming-matches-header-container" ng-click="toggle('incoming')">
+        <a class="matches-header">Incoming Matches</a>
+        <span ng-class="classes['incoming']" class="click-to-expand"></span>
+    </div>
+
+    <div class="user" ng-repeat="user in incoming" ng-show="expanded['incoming']">
+        <p>{{user.name}}</p>
+        <!-- Something for status -->
+    </div>
+</li>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -1,34 +1,34 @@
-<li class="matches-container menu-item">
-    <div class="matches-header-container" ng-click="toggle('matches')">
+<li class="matches-container">
+    <div class="matches-header-container menu-item" ng-click="toggle('matches')">
         <a class="matches-header heading">My Matches</a>
         <span ng-class="classes['matches']" class="click-to-expand"></span>
     </div>
 
-    <div class="user" ng-repeat="user in matches" ng-show="expanded['matches']">
-        <p>{{user.name}}</p>
+    <div class="user menu-item subitem" ng-repeat="user in matches" ng-show="expanded['matches']">
+        <a class="heading">{{user.name}}</a>
     </div>
 </li>
 
-<li class="pending-matches-container menu-item">
-    <div class="pending-matches-header-container" ng-click="toggle('pending')">
+<li class="pending-matches-container" ng-show="showPending()">
+    <div class="pending-matches-header-container menu-item" ng-click="toggle('pending')">
         <a class="pending-matches-header heading">Pending Matches</a>
+        <span class="notification">({{pending.length}})</span>
         <span ng-class="classes['pending']" class="click-to-expand"></span>
     </div>
 
-    <div class="user" ng-repeat="user in pending" ng-show="expanded['pending']">
-        <p>{{user.name}}</p>
-        <!-- Something for status -->
+    <div class="user menu-item subitem" ng-repeat="user in pending" ng-show="expanded['pending'] ">
+        <a class="heading">{{user.name}}</a>
     </div>
 </li>
 
-<li class="incoming-matches-container menu-item">
-    <div class="incoming-matches-header-container" ng-click="toggle('incoming')">
+<li class="incoming-matches-container" ng-show="showIncoming()">
+    <div class="incoming-matches-header-container menu-item" ng-click="toggle('incoming')">
         <a class="incoming-matches-header heading">Incoming Matches</a>
+        <span class="notification">({{incoming.length}})</span>
         <span ng-class="classes['incoming']" class="click-to-expand"></span>
     </div>
 
-    <div class="user" ng-repeat="user in incoming" ng-show="expanded['incoming']">
-        <p>{{user.name}}</p>
-        <!-- Something for status -->
+    <div class="user menu-item subitem" ng-repeat="user in incoming" ng-show="expanded['incoming']">
+        <a class="heading">{{user.name}}</a>
     </div>
 </li>

--- a/app/assets/html/sidebar_matching.html
+++ b/app/assets/html/sidebar_matching.html
@@ -4,8 +4,9 @@
         <span ng-class="classes['matches']" class="click-to-expand"></span>
     </div>
 
-    <div class="user menu-item subitem" ng-repeat="user in matches" ng-show="expanded['matches']">
+    <div class="user menu-item subitem" ng-repeat="user in matches" ng-show="expanded['matches']" ng-click="goToProfile(user.id)">
         <a class="heading">{{user.name}}</a>
+        <span class="btn btn-primary" ng-click="matchWith(user.id)">Match</span>
     </div>
 </li>
 

--- a/app/assets/javascripts/homepage/router.coffee
+++ b/app/assets/javascripts/homepage/router.coffee
@@ -19,6 +19,10 @@ router.config(["$stateProvider", "$urlRouterProvider", ($stateProvider, $urlRout
                 templateUrl: "/assets/sidebar.html"
                 controller: "SidebarController"
             }
+            "sidebar-matching@root": {
+                templateUrl: "/assets/sidebar_matching.html"
+                controller: "SidebarMatchesController"
+            }
         }
         resolve: {
             loggedIn: ["Authentication", "$window", "$q", (Authentication, $window, $q) ->

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -77,17 +77,40 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         else
             $scope.classes[which] = notExpandedClasses
 
-    $scope.pending = [
-        { name: "bob" }
-        { name: "janice" }
-    ]
+    $scope.matches = []
+    $scope.pending = []
+    $scope.incoming = []
 
     $scope.showPending = () -> $scope.pending.length > 0
-
-    $scope.incoming = [
-        { name: "john" }
-        { name: "george" }
-    ]
-
     $scope.showIncoming = () -> $scope.incoming.length > 0
+
+    reloadSidebarMatches = () ->
+        $scope.matches = [
+            { name: "bob" }
+            { name: "john" }
+        ]
+
+    reloadSidebarNotifications = () ->
+        API.outgoingInvites()
+            .success (invites) ->
+                $scope.pending = invites.outgoing
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
+
+        API.incomingInvites()
+            .success (invites) ->
+                $scope.incoming = invites.incoming
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
+
+    reloadSidebarMatches()
+    reloadSidebarNotifications()
 ])

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -29,7 +29,7 @@ sidebar.controller("SidebarController", ["$scope", "$http", "$state", "API", "Ti
                 if result?
                     reason = result.error
                 else
-                reason = "status code #{status}"
+                    reason = "status code #{status}"
                 console.log "sidebar failed: #{reason}"
 
     reloadSidebarArenas = () ->

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -1,8 +1,6 @@
 sidebar = angular.module("Sidebar", ["SharedServices"])
 
 sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API", "TimeUtil", "AppState", ($scope, $rootScope, $state, API, TimeUtil, AppState, SidebarService) ->
-    SIDEBAR_REFRESH_RATE = 5000
-
     MAX_PREVIEW_TEXT_LENGTH = 100;
     authorTextForId = (id) -> if id == currentUserId then "You" else $scope.gladiatorNameById[id]
     previewTextFromPost = (text) -> if text.length > MAX_PREVIEW_TEXT_LENGTH then text.substr(0, MAX_PREVIEW_TEXT_LENGTH) + "..." else text
@@ -63,8 +61,11 @@ sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API"
 
     reloadSidebarArenas()
 
+    # Register events to trigger sidebar reloading
     $rootScope.$on("reloadSidebarArenas", reloadSidebarArenas)
 
+    # Refresh the sidebar every few seconds
+    SIDEBAR_REFRESH_RATE = 5000
     setInterval(() ->
         $rootScope.$broadcast("reloadSidebarArenas")
         $rootScope.$broadcast("reloadSidebarNotifications")
@@ -72,6 +73,7 @@ sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API"
 ])
 
 sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state", "API", ($scope, $rootScope, $state, API) ->
+    # Toggling different views
     notExpandedClasses = ["glyphicon", "glyphicon-chevron-down"]
     expandedClasses = ["glyphicon", "glyphicon-chevron-up"]
 
@@ -85,6 +87,7 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state"
         else
             $scope.classes[which] = notExpandedClasses
 
+    # Controls for handling matches and match invitations
     $scope.matchWith = (id) ->
         API.sendInvite(id)
             .success (result) ->
@@ -126,6 +129,7 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state"
                     reason = "status code #{status}"
                 console.log "sidebar failed: #{reason}"
 
+    # Helpers to refresh and store matches and invites
     $scope.matches = []
     $scope.pending = []
     $scope.incoming = []
@@ -168,6 +172,7 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state"
     reloadSidebarMatches()
     reloadSidebarNotifications()
 
+    # Register events to trigger sidebar reloading
     $rootScope.$on("reloadSidebarMatches", reloadSidebarMatches)
     $rootScope.$on("reloadSidebarNotifications", reloadSidebarNotifications)
 ])

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -1,6 +1,7 @@
 sidebar = angular.module("Sidebar", ["SharedServices"])
 
 sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API", "TimeUtil", "AppState", ($scope, $rootScope, $state, API, TimeUtil, AppState, SidebarService) ->
+    SIDEBAR_REFRESH_RATE = 5000
 
     MAX_PREVIEW_TEXT_LENGTH = 100;
     authorTextForId = (id) -> if id == currentUserId then "You" else $scope.gladiatorNameById[id]
@@ -64,15 +65,13 @@ sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API"
 
     $rootScope.$on("reloadSidebarArenas", reloadSidebarArenas)
 
-    setTimeout(() ->
+    setInterval(() ->
         $rootScope.$broadcast("reloadSidebarArenas")
         $rootScope.$broadcast("reloadSidebarNotifications")
-    , MATCH_TIMEOUT_PERIOD)
+    , SIDEBAR_REFRESH_RATE)
 ])
 
 sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state", "API", ($scope, $rootScope, $state, API) ->
-    MATCH_TIMEOUT_PERIOD = 5000
-
     notExpandedClasses = ["glyphicon", "glyphicon-chevron-down"]
     expandedClasses = ["glyphicon", "glyphicon-chevron-up"]
 

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -1,6 +1,6 @@
 sidebar = angular.module("Sidebar", ["SharedServices"])
 
-sidebar.controller("SidebarController", ["$scope", "$http", "$state", "API", "TimeUtil", "AppState", ($scope, $http, $state, API, TimeUtil, AppState) ->
+sidebar.controller("SidebarController", ["$scope", "$state", "API", "TimeUtil", "AppState", ($scope, $state, API, TimeUtil, AppState) ->
 
     MAX_PREVIEW_TEXT_LENGTH = 100;
     authorTextForId = (id) -> if id == currentUserId then "You" else $scope.gladiatorNameById[id]
@@ -61,4 +61,19 @@ sidebar.controller("SidebarController", ["$scope", "$http", "$state", "API", "Ti
                 console.log "sidebar failed: #{reason}"
 
     reloadSidebarArenas()
+])
+
+sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppState", ($scope, $state, API, AppState) ->
+    notExpandedClasses = ["glyphicon", "glyphicon-chevron-down"]
+    expandedClasses = ["glyphicon", "glyphicon-chevron-up"]
+
+    $scope.expanded = { "pending": false, "matches": false, "incoming": false }
+    $scope.classes = { "pending": notExpandedClasses, "matches": notExpandedClasses, "incoming": notExpandedClasses }
+
+    $scope.toggle = (which) ->
+        $scope.expanded[which] = !$scope.expanded[which]
+        if $scope.expanded[which]
+            $scope.classes[which] = expandedClasses
+        else
+            $scope.classes[which] = notExpandedClasses
 ])

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -1,6 +1,6 @@
 sidebar = angular.module("Sidebar", ["SharedServices"])
 
-sidebar.controller("SidebarController", ["$scope", "$state", "API", "TimeUtil", "AppState", ($scope, $state, API, TimeUtil, AppState) ->
+sidebar.controller("SidebarController", ["$scope", "$rootScope", "$state", "API", "TimeUtil", "AppState", ($scope, $rootScope, $state, API, TimeUtil, AppState, SidebarService) ->
 
     MAX_PREVIEW_TEXT_LENGTH = 100;
     authorTextForId = (id) -> if id == currentUserId then "You" else $scope.gladiatorNameById[id]
@@ -61,9 +61,18 @@ sidebar.controller("SidebarController", ["$scope", "$state", "API", "TimeUtil", 
                 console.log "sidebar failed: #{reason}"
 
     reloadSidebarArenas()
+
+    $rootScope.$on("reloadSidebarArenas", reloadSidebarArenas)
+
+    setTimeout(() ->
+        $rootScope.$broadcast("reloadSidebarArenas")
+        $rootScope.$broadcast("reloadSidebarNotifications")
+    , MATCH_TIMEOUT_PERIOD)
 ])
 
-sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppState", ($scope, $state, API, AppState) ->
+sidebar.controller("SidebarMatchesController", ["$scope", "$rootScope", "$state", "API", ($scope, $rootScope, $state, API) ->
+    MATCH_TIMEOUT_PERIOD = 5000
+
     notExpandedClasses = ["glyphicon", "glyphicon-chevron-down"]
     expandedClasses = ["glyphicon", "glyphicon-chevron-up"]
 
@@ -78,7 +87,17 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
             $scope.classes[which] = notExpandedClasses
 
     $scope.matchWith = (id) ->
-        # Matching
+        API.sendInvite(id)
+            .success (result) ->
+                reloadSidebarMatches()
+                reloadSidebarNotifications()
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
+
         reloadSidebarMatches()
         reloadSidebarNotifications()
 
@@ -89,6 +108,7 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         API.acceptInvite(id)
             .success (invites) ->
                 reloadSidebarNotifications()
+                $rootScope.$broadcast("reloadSidebarArenas")
             .error (result, status) ->
                 if result?
                     reason = result.error
@@ -115,19 +135,20 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
     $scope.showIncoming = () -> $scope.incoming.length > 0
 
     reloadSidebarMatches = () ->
-        $scope.matches = [
-            { name: "bob", id: 1 }
-            { name: "john", id: 2 }
-        ]
+        API.matches()
+            .success (matches) ->
+                $scope.matches = matches
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
 
     reloadSidebarNotifications = () ->
         API.outgoingInvites()
             .success (invites) ->
                 $scope.pending = invites.outgoing
-                $scope.pending = [
-                    { name: "bob", id: 1 }
-                    { name: "john", id: 2 }
-                ]
             .error (result, status) ->
                 if result?
                     reason = result.error
@@ -138,10 +159,6 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         API.incomingInvites()
             .success (invites) ->
                 $scope.incoming = invites.incoming
-                $scope.incoming = [
-                    { name: "bob", id: 1 }
-                    { name: "john", id: 2 }
-                ]
             .error (result, status) ->
                 if result?
                     reason = result.error
@@ -151,4 +168,7 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
 
     reloadSidebarMatches()
     reloadSidebarNotifications()
+
+    $rootScope.$on("reloadSidebarMatches", reloadSidebarMatches)
+    $rootScope.$on("reloadSidebarNotifications", reloadSidebarNotifications)
 ])

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -77,6 +77,11 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         else
             $scope.classes[which] = notExpandedClasses
 
+    $scope.matchWith = (id) ->
+        x = 1
+    $scope.goToProfile = (id) ->
+        $state.go("profile", { id: id })
+
     $scope.matches = []
     $scope.pending = []
     $scope.incoming = []
@@ -86,8 +91,8 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
 
     reloadSidebarMatches = () ->
         $scope.matches = [
-            { name: "bob" }
-            { name: "john" }
+            { name: "bob", id: 1 }
+            { name: "john", id: 2 }
         ]
 
     reloadSidebarNotifications = () ->

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -78,9 +78,34 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
             $scope.classes[which] = notExpandedClasses
 
     $scope.matchWith = (id) ->
-        x = 1
+        # Matching
+        reloadSidebarMatches()
+        reloadSidebarNotifications()
+
     $scope.goToProfile = (id) ->
         $state.go("profile", { id: id })
+
+    $scope.accept = (id) ->
+        API.acceptInvite(id)
+            .success (invites) ->
+                reloadSidebarNotifications()
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
+
+    $scope.reject = (id) ->
+        API.rejectInvite(id)
+            .success (invites) ->
+                reloadSidebarNotifications()
+            .error (result, status) ->
+                if result?
+                    reason = result.error
+                else
+                    reason = "status code #{status}"
+                console.log "sidebar failed: #{reason}"
 
     $scope.matches = []
     $scope.pending = []
@@ -99,6 +124,10 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         API.outgoingInvites()
             .success (invites) ->
                 $scope.pending = invites.outgoing
+                $scope.pending = [
+                    { name: "bob", id: 1 }
+                    { name: "john", id: 2 }
+                ]
             .error (result, status) ->
                 if result?
                     reason = result.error
@@ -109,6 +138,10 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
         API.incomingInvites()
             .success (invites) ->
                 $scope.incoming = invites.incoming
+                $scope.incoming = [
+                    { name: "bob", id: 1 }
+                    { name: "john", id: 2 }
+                ]
             .error (result, status) ->
                 if result?
                     reason = result.error

--- a/app/assets/javascripts/homepage/sidebar.coffee
+++ b/app/assets/javascripts/homepage/sidebar.coffee
@@ -76,4 +76,18 @@ sidebar.controller("SidebarMatchesController", ["$scope", "$state", "API", "AppS
             $scope.classes[which] = expandedClasses
         else
             $scope.classes[which] = notExpandedClasses
+
+    $scope.pending = [
+        { name: "bob" }
+        { name: "janice" }
+    ]
+
+    $scope.showPending = () -> $scope.pending.length > 0
+
+    $scope.incoming = [
+        { name: "john" }
+        { name: "george" }
+    ]
+
+    $scope.showIncoming = () -> $scope.incoming.length > 0
 ])

--- a/app/assets/javascripts/shared/api.coffee
+++ b/app/assets/javascripts/shared/api.coffee
@@ -59,6 +59,10 @@ angular.module("SharedServices").service("API", ["$http", "$cookieStore", ($http
         request = generateRequest("conversation/#{id}")
         $http.get(request, { params: { token: getToken() } })
 
+    this.createConversationByUser = (id) ->
+        request = generateRequest("conversation/create/#{id}")
+        $http.post(request, { token: getToken() })
+
     this.createPostByConversationId = (id, text) ->
         request = generateRequest("post/create/#{id}")
         $http.post(request, { text: text, token: getToken() })

--- a/app/assets/javascripts/shared/api.coffee
+++ b/app/assets/javascripts/shared/api.coffee
@@ -85,6 +85,11 @@ angular.module("SharedServices").service("API", ["$http", "$cookieStore", ($http
 
     this.approveResolutionByConversationId = (conversationId) ->
         request = generateRequest("conversation/approve_resolution/#{conversationId}")
+        $http.post(request, { token: getToken() })
+
+    this.matches = () ->
+        request = generateRequest("matches")
+        $http.get(request, { params: { token: getToken() } })
 
     this.outgoingInvites = () ->
         request = generateRequest("invites/outgoing")

--- a/app/assets/javascripts/shared/api.coffee
+++ b/app/assets/javascripts/shared/api.coffee
@@ -85,6 +85,25 @@ angular.module("SharedServices").service("API", ["$http", "$cookieStore", ($http
 
     this.approveResolutionByConversationId = (conversationId) ->
         request = generateRequest("conversation/approve_resolution/#{conversationId}")
+
+    this.outgoingInvites = () ->
+        request = generateRequest("invites/outgoing")
+        $http.get(request, { params: { token: getToken() } })
+
+    this.incomingInvites = () ->
+        request = generateRequest("invites/incoming")
+        $http.get(request, { params: { token: getToken() } })
+
+    this.sendInvite = (id) ->
+        request = generateRequest("invite/send/#{id}")
+        $http.post(request, { token: getToken() })
+
+    this.acceptInvite = (id) ->
+        request = generateRequest("invite/accept/#{id}")
+        $http.post(request, { token: getToken() })
+
+    this.rejectInvite = (id) ->
+        request = generateRequest("invite/reject/#{id}")
         $http.post(request, { token: getToken() })
 
     return

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -248,6 +248,11 @@ p {
         }
     }
 
+    .btn {
+        background-color: #aab2bd;
+        border-color: #aab2bd;
+    }
+
     .subitem {
         border-top: 1px dotted #E1E1E1;
         padding-left: 25px;
@@ -272,6 +277,12 @@ p {
         border-bottom: 1px solid #E1E1E1;
 
         li {
+            .notification {
+                font-size: 16px;
+                color: #ccc;
+                margin-left: 5px;
+            }
+
             &:last-child {
                 border-bottom: 1px solid #E1E1E1;
             }

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -230,6 +230,30 @@ p {
         display: block;
     }
 
+    .click-to-expand {
+        font-size: 16px;
+        color: black;
+        float: right;
+        padding-right: 5px;
+        padding-top: 8px;
+    }
+
+    .sidebar-matching-container {
+        padding-bottom: 5px;
+        border-bottom: 1px solid #E1E1E1;
+
+        a {
+            font-size: 16px;
+            color: #888;
+        }
+
+        li {
+            &:last-child {
+                border-bottom: 1px solid #E1E1E1;
+            }
+        }
+    }
+
     .gladiator-heading-container {
         padding-top: 10px;
         padding-bottom: 10px;
@@ -241,14 +265,6 @@ p {
         .gladiator-heading {
             font-size: 16px;
             color: #888;
-        }
-
-        .click-to-expand {
-            font-size: 16px;
-            color: black;
-            float: right;
-            padding-right: 5px;
-            padding-top: 8px;
         }
     }
 

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -230,6 +230,19 @@ p {
         display: block;
     }
 
+    .menu-item {
+        padding: 5px 10px;
+
+        &:hover {
+            background-color: #F8F8F8;
+        }
+    }
+
+    .subitem {
+        border-top: 1px dotted #E1E1E1;
+        padding-left: 25px;
+    }
+
     .click-to-expand {
         font-size: 16px;
         color: black;
@@ -238,14 +251,15 @@ p {
         padding-top: 8px;
     }
 
+    .heading {
+        font-size: 16px;
+        color: #888;
+        text-decoration: none;
+    }
+
     .sidebar-matching-container {
         padding-bottom: 5px;
         border-bottom: 1px solid #E1E1E1;
-
-        a {
-            font-size: 16px;
-            color: #888;
-        }
 
         li {
             &:last-child {
@@ -254,22 +268,7 @@ p {
         }
     }
 
-    .gladiator-heading-container {
-        padding-top: 10px;
-        padding-bottom: 10px;
-
-        &:hover {
-            background-color: #f9f9f9;
-        }
-
-        .gladiator-heading {
-            font-size: 16px;
-            color: #888;
-        }
-    }
-
     li {
-        padding: 5px 5px 0px 5px;
         border-bottom: 1px solid #E1E1E1;
 
         @media(max-width: 768px) {
@@ -279,20 +278,6 @@ p {
         }
 
         .conversation-start-container {
-            padding: 10px;
-            padding-left: 25px;
-            border-top: 1px dotted #E1E1E1;
-
-            &:hover {
-                background-color: #F8F8F8;
-            }
-
-            .conversation-start {
-                padding: 0;
-                font-size: 16px;
-                color: #888;
-            }
-
             .glyphicon-plus {
                 float: right;
                 font-size: 10px;
@@ -301,23 +286,14 @@ p {
         }
 
         .conversation-preview {
-            padding: 10px;
-            padding-left: 25px;
             font-size: 13px;
             background-color: #ffffff;
-            border-top: 1px dotted #e1e1e1;
-
-            &:hover {
-                background-color: #F8F8F8;
-            }
 
             .conversation-heading {
 
                 .conversation-title {
-                    color: #888;
-                    margin-bottom: 0px;
+                    margin: 0;
                     line-height: 1.7;
-                    font-size: 16px;
                 }
 
                 .conversation-actions {
@@ -332,23 +308,14 @@ p {
             }
 
             .conversation-time {
+                margin: 0;
                 color: #ccc;
-                padding-right: 5px;
-                margin-bottom: 0px;
             }
 
             .conversation-text {
-                margin-top: 0px;
-                padding-right: 5px;
-                margin-bottom: 5px;
+                margin: 0;
                 line-height: 1.7;
             }
-        }
-
-        a {
-            text-decoration: none;
-            font-size: 13px;
-            padding-left: 10px;
         }
     }
 

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -264,7 +264,7 @@ p {
 
         .conversation-start-container {
             padding: 10px;
-            padding-left: 20px;
+            padding-left: 25px;
             border-top: 1px dotted #E1E1E1;
 
             &:hover {
@@ -286,7 +286,7 @@ p {
 
         .conversation-preview {
             padding: 10px;
-            padding-left: 20px;
+            padding-left: 25px;
             font-size: 13px;
             background-color: #ffffff;
             border-top: 1px dotted #e1e1e1;
@@ -306,6 +306,7 @@ p {
 
                 .conversation-actions {
                     float: right;
+                    margin-left: 5px;
 
                     .conversation-advance {
                         font-size: 10px;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -27,6 +27,15 @@ h1, h2, h3, p, div {
     align-items: center;
 }
 
+.unselectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
 input[type=text], input[type=password] {
     background: #ffffff;
     border-radius: 15px;
@@ -207,6 +216,7 @@ p {
     overflow: auto;
     font-size: 12px;
     font-weight: 300;
+    .unselectable();
 
     @media(min-width: 768px) {
         padding-top: 50px;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -254,7 +254,7 @@ p {
 
     li {
         padding: 5px 5px 0px 5px;
-        border-bottom: 1px solid #D4D4D4;
+        border-bottom: 1px solid #E1E1E1;
 
         @media(max-width: 768px) {
             &:last-child {
@@ -265,7 +265,7 @@ p {
         .conversation-start-container {
             padding: 10px;
             padding-left: 20px;
-            border-top: 1px dotted #D4D4D4;
+            border-top: 1px dotted #E1E1E1;
 
             &:hover {
                 background-color: #F8F8F8;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -248,11 +248,6 @@ p {
         }
     }
 
-    .btn {
-        background-color: #aab2bd;
-        border-color: #aab2bd;
-    }
-
     .subitem {
         border-top: 1px dotted #E1E1E1;
         padding-left: 25px;
@@ -276,12 +271,20 @@ p {
         padding-bottom: 5px;
         border-bottom: 1px solid #E1E1E1;
 
+        .notification {
+            font-size: 16px;
+            color: #ccc;
+            margin-left: 5px;
+        }
+
+        .user .btn {
+            float: right;
+            font-size: 10px;
+            margin-top: 4px;
+            margin-left: 5px;
+        }
+
         li {
-            .notification {
-                font-size: 16px;
-                color: #ccc;
-                margin-left: 5px;
-            }
 
             &:last-child {
                 border-bottom: 1px solid #E1E1E1;
@@ -324,6 +327,7 @@ p {
                     .conversation-advance {
                         font-size: 10px;
                         padding: 6px 8px;
+
                     }
                 }
             }

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -262,6 +262,28 @@ p {
             }
         }
 
+        .conversation-start-container {
+            padding: 10px;
+            padding-left: 20px;
+            border-top: 1px dotted #D4D4D4;
+
+            &:hover {
+                background-color: #F8F8F8;
+            }
+
+            .conversation-start {
+                padding: 0;
+                font-size: 16px;
+                color: #888;
+            }
+
+            .glyphicon-plus {
+                float: right;
+                font-size: 10px;
+                padding: 6px 8px;
+            }
+        }
+
         .conversation-preview {
             padding: 10px;
             padding-left: 20px;

--- a/app/assets/stylesheets/homePage.less
+++ b/app/assets/stylesheets/homePage.less
@@ -306,6 +306,7 @@ p {
                 float: right;
                 font-size: 10px;
                 padding: 6px 8px;
+                margin-top: 2px;
             }
         }
 
@@ -327,7 +328,7 @@ p {
                     .conversation-advance {
                         font-size: 10px;
                         padding: 6px 8px;
-
+                        margin-top: 2px;
                     }
                 }
             }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,8 @@ class ApplicationController < ActionController::Base
             render_error(:invalid_token)
         end
     end
+
+    def get_authenticated_user
+        return @token_results[:user]
+    end
 end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -24,7 +24,7 @@ class ConversationsController < ApplicationController
             arenas = Arena.for_users(user, other_user)
 
             if arenas.length == 0
-                render_error(:resource_not_found, :resource => :arena)
+                render_error(:resource_not_found, :resource => :arena) and return
             end
 
             arena = arenas[0]

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -24,6 +24,25 @@ class ConversationsController < ApplicationController
             arenas = Arena.for_users(user, other_user)
 
             if arenas.length == 0
+                render_error(:resource_not_found, :resource => :arena)
+            end
+
+            arena = arenas[0]
+            conversation = arena.conversations.create :title => "Untitled Conversation"
+            render :json => { :id => conversation.id }
+        else
+            render_error(:resource_not_found, :resource => :other_user)
+        end
+    end
+
+    def create
+        user = @token_results[:user]
+        other_user = User.find_by_id(params[:user_id])
+
+        if other_user.present?
+            arenas = Arena.for_users(user, other_user)
+
+            if arenas.length == 0
                 render_error(:resource_not_found, :resource => :arena) and return
             end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -16,6 +16,25 @@ class ConversationsController < ApplicationController
         end
     end
 
+    def create
+        user = @token_results[:user]
+        other_user = User.find_by_id(params[:user_id])
+
+        if other_user.present?
+            arenas = Arena.for_users(user, other_user)
+
+            if arenas.length == 0
+                render_error(:resource_not_found, :resource => :arena)
+            end
+
+            arena = arenas[0]
+            conversation = arena.conversations.create :title => "Untitled Conversation"
+            render :json => { :id => conversation.id }
+        else
+            render_error(:resource_not_found, :resource => :other_user)
+        end
+    end
+
     def approve_summary
         edit_or_approve_resolution_or_summary :user_did_approve_summary, :approved_summary, :approve
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,14 +3,14 @@ class UsersController < ApplicationController
     skip_filter :check_access_token, :only => [:can_register, :register, :login]
 
     def matches
-        user = User.find_by_id(params[:id])
+        user = get_authenticated_user()
         if user.present?
             render :json => user.matches
         else
             render :json => []
         end
     end
-    
+
     def authenticate
         user = @token_results[:user]
         render :json => { :user => user.response_object }

--- a/app/models/arena.rb
+++ b/app/models/arena.rb
@@ -4,6 +4,10 @@ class Arena < ActiveRecord::Base
     has_many :conversations
     attr_accessible :user1, :user2
 
+    scope :for_users, ->(user1, user2) do
+        where("(user1_id = :user1 AND user2_id = :user2) OR (user1_id = :user2 AND user2_id = :user1)", :user1 => user1, :user2 => user2)
+    end
+
     def response_object
         conversations_response = []
         conversations.each do |conversation|

--- a/app/util/error_handler.rb
+++ b/app/util/error_handler.rb
@@ -29,8 +29,8 @@ module ErrorHandler
         :unauthorized_access => 401
     }
 
-    def render_error(error)
-        render :json => { :error => ERROR[error] }, :status => ERROR_CODE[error]
+    def render_error(error, args = {})
+        render :json => { :error => ERROR[error] }.merge(args), :status => ERROR_CODE[error]
     end
 
 end

--- a/app/util/error_handler.rb
+++ b/app/util/error_handler.rb
@@ -22,10 +22,10 @@ module ErrorHandler
         :invalid_password => 400,
         :user_exists => 400,
         :resource_not_found => 404,
+        :no_such_conversation => 404,
+        :no_such_conversation_or_user => 404,
         :cannot_invite => 400,
         :cannot_accept_or_reject => 400,
-        :no_such_conversation => 401,
-        :no_such_conversation_or_user => 401,
         :unauthorized_access => 401
     }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ CS169PenpalGladiators::Application.routes.draw do
     post "/api/v1/user/:id/profile" => "users#post_profile_info_by_id"
     get "/api/v1/arenas/:user_id" => "arenas#get_by_user_id"
     get "/api/v1/conversation/:id" => "conversations#get_by_id"
+    post "/api/v1/conversation/create/:user_id" => "conversations#create"
     post "/api/v1/post/create/:conversation_id" => "posts#create"
     post "/api/v1/post/edit/:post_id" => "posts#edit"
     get "/api/v1/invites/outgoing" => "invites#outgoing"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150425025047) do
+ActiveRecord::Schema.define(:version => 20150426202521) do
 
   create_table "arenas", :force => true do |t|
     t.integer  "user1_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,14 @@ ActiveRecord::Schema.define(:version => 20150425025047) do
   add_index "posts", ["conversation_id"], :name => "index_posts_on_conversation_id"
   add_index "posts", ["user_id"], :name => "index_posts_on_user_id"
 
+  create_table "response_weights", :force => true do |t|
+    t.integer  "response1_id"
+    t.integer  "response2_id"
+    t.integer  "weight"
+    t.datetime "created_at",   :null => false
+    t.datetime "updated_at",   :null => false
+  end
+
   create_table "survey_questions", :force => true do |t|
     t.string   "text"
     t.integer  "topic_id"
@@ -110,4 +118,3 @@ ActiveRecord::Schema.define(:version => 20150425025047) do
   end
 
 end
-

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -20,10 +20,11 @@ describe ConversationsController do
             Conversation.stub(:find_by_id).and_return(nil)
             get "get_by_id", :id => 2
             response_object = JSON.parse(response.body)
-            expect(response_object["error"]).to eq("no such conversation")
+            expect(response_object["error"]).not_to be(nil)
             expect(response_object["id"]).to eq(nil)
             expect(response_object["title"]).to eq(nil)
             expect(response_object["posts"]).to eq(nil)
+            expect(response.status).to eq(404)
         end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -74,7 +74,8 @@ describe UsersController, :type => :controller do
         end
 
         it "should return the correct matches" do
-            get "matches", :id => User.find_by_email("ben@bitdiddle.com").id, :token => ""
+            controller.stub(:get_authenticated_user).and_return(User.find_by_email("ben@bitdiddle.com"))
+            get "matches"
             responseObject = JSON.parse(response.body)
             expect(responseObject.first["user"]["id"]).to eq User.find_by_email("rosenthal@policy.com").id
         end


### PR DESCRIPTION
Merge sidebar frontend matching with backend.

Outstanding bugs
- The matching algorithm does not take invitations into account. Therefore, you get matched with people that you shouldn't and the code errors when you try to match with them.

CSS Changes
- A few more css changes to make buttons look nice etc.
- Refactored CSS to make more sense within the sidebar.
- CSS can still use refactoring.

Controller
- An additional controller was added to handle sidebar matching to make it cleaner
- An additional subview was added as well to split out that logic

Controller Logic
- Main interesting point is that eventing is used for the first time in our app to trigger sidebar reloads from other controllers.
  - This was done because a shared service made no sense in this case. There is no data shared, it's just triggering an action.
- The sidebar is currently set to automatically reload every 5 seconds on an interval. I didn't do any complex reloading similar to the conversation page since it shouldn't be too common for a user to perform any actions on the sidebar for it to be worth resetting the interval time. Therefore, this is database intensive that we may be able to cache in the future.

Backend
- Added a new way to get the user in the backend instead of using the instance variable. This makes it possible for tests to stub the logic of authentication without depending on the instance variable.
- 
