### PR TITLE
Post storage

### DIFF
--- a/app/assets/javascripts/homepage/conversation.coffee
+++ b/app/assets/javascripts/homepage/conversation.coffee
@@ -18,7 +18,7 @@ conversation.directive("onEnter", ->
         )
 )
 
-conversation.controller("ConversationController", ["$scope", "$stateParams", "API", "TimeUtil", "AppState", "$rootScope", "ConversationData", ($scope, $stateParams, API, TimeUtil, AppState, $rootScope, ConversationData) ->
+conversation.controller("ConversationController", ["$scope", "$stateParams", "API", "TimeUtil", "AppState", "$rootScope", "ConversationService", "ConversationData", ($scope, $stateParams, API, TimeUtil, AppState, $rootScope, ConversationService, ConversationData) ->
     # Constants
     POST_SUBMISSION_TIMEOUT_PERIOD_MS = 5000
     CONVERSATION_POLL_PERIOD = 10 # seconds
@@ -168,6 +168,11 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
         $scope.editPostText = if conversation.resolution then conversation.resolution.text else ""
         expandEditorViewForState(EDIT_RESOLUTION)
 
+    # Handle editor switching state, ex. writing a new post and switching (before submitting) to editing an old post
+    handleEditorStateChange = (state) ->
+        # TODO: implement this
+        return
+
     expandEditorViewForState = (state) ->
         if conversationPageState is READ_POSTS and state isnt READ_POSTS
             postsContainer = document.getElementById("posts-container")
@@ -235,3 +240,27 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
 
     parseConversation(ConversationData.data, true)
 ])
+
+conversation.service("ConversationService", () ->
+    conversations = {}
+    getConversation = (conversationId) ->
+        if conversationId of conversations
+            return conversations[conversationId]
+        else
+            c = {addPostText: "", summaryText: "", resolutionText: ""}
+            conversations[conversationId] = c
+            return c
+    this.updateAddPostText = (conversationId, text) ->
+        getConversation(conversationId).addPostText = text
+    this.updateSummaryText = (conversationId, text) ->
+        getConversation(conversationId).summaryText = text
+    this.updateResolutionText = (conversationId, text) ->
+        getConversation(conversationId).resolutionText = text
+    this.getAddPostText = (conversationId) ->
+        return getConversation(conversationId).addPostText
+    this.getSummaryText = (conversationId) ->
+        return getConversation(conversationId).summaryText
+    this.getResolutionText = (conversationId) ->
+        return getConversation(conversationId).resolutionText
+    return
+)

--- a/app/assets/javascripts/homepage/conversation.coffee
+++ b/app/assets/javascripts/homepage/conversation.coffee
@@ -230,7 +230,7 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
 
     $rootScope.$on "conversationPageWillLoad", (scope, args) ->
         if conversationId isnt args.conversationId then clearInterval conversationPollingProcess
-    $rootScope.$on '$locationChangeStart', (event, next, current) ->
+    $rootScope.$on "$locationChangeStart", (event, next, current) ->
         savePostInProgress()
 
     parseConversation = (response, scrollToEnd) ->
@@ -261,29 +261,29 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
 ])
 
 conversation.service("ConversationService", () ->
-    conversations = {}
-    getConversation = (conversationId) ->
-        if conversationId of conversations
-            return conversations[conversationId]
+    conversationTexts = {}
+    getConversationText = (conversationId) ->
+        if conversationId of conversationTexts
+            return conversationTexts[conversationId]
         else
             c = {addPostText: "", summaryText: "", resolutionText: ""}
-            conversations[conversationId] = c
+            conversationTexts[conversationId] = c
             return c
     # getter and setter for posts in progress
     this.updateAddPostText = (conversationId, text) ->
-        getConversation(conversationId).addPostText = text
+        getConversationText(conversationId).addPostText = text
     this.updateSummaryText = (conversationId, text) ->
-        getConversation(conversationId).summaryText = text
+        getConversationText(conversationId).summaryText = text
     this.updateResolutionText = (conversationId, text) ->
-        getConversation(conversationId).resolutionText = text
+        getConversationText(conversationId).resolutionText = text
     this.getAddPostText = (conversationId) ->
-        return getConversation(conversationId).addPostText
+        return getConversationText(conversationId).addPostText
     this.getSummaryText = (conversationId) ->
-        return getConversation(conversationId).summaryText
+        return getConversationText(conversationId).summaryText
     this.getResolutionText = (conversationId) ->
-        return getConversation(conversationId).resolutionText
+        return getConversationText(conversationId).resolutionText
     this.hasUnsavedProgress = (conversationId) ->
-        c = getConversation(conversationId)
-        return (c.addPostText || c.summaryText || c.resolutionText)
+        c = getConversationText(conversationId)
+        return (c.addPostText != "" or c.summaryText != "" or c.resolutionText != "")
     return
 )

--- a/app/assets/javascripts/homepage/conversation.coffee
+++ b/app/assets/javascripts/homepage/conversation.coffee
@@ -230,6 +230,8 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
 
     $rootScope.$on "conversationPageWillLoad", (scope, args) ->
         if conversationId isnt args.conversationId then clearInterval conversationPollingProcess
+    $rootScope.$on '$locationChangeStart', (event, next, current) ->
+        savePostInProgress()
 
     parseConversation = (response, scrollToEnd) ->
         conversation.id = response.id

--- a/app/assets/javascripts/homepage/conversation.coffee
+++ b/app/assets/javascripts/homepage/conversation.coffee
@@ -77,14 +77,15 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
             return "post-content-resolution"
         return ""
     $scope.addPostClicked = ->
+        savePostInProgress()
         $scope.postSubmitError = ""
-        $scope.editPostText = "" if currentPostEditId # Clear the editor if the user was previously editing an existing post.
+        $scope.editPostText = ConversationService.getAddPostText(conversationId)
         currentPostEditId = null
         expandEditorViewForState(EDIT_OR_ADD_POST)
 
     $scope.shouldDisplayEmptyConversationsMessage = -> !$scope.posts or $scope.posts.length == 0
-    $scope.cancelPostClicked = -> conversationPageState = READ_POSTS
-    $scope.escapeTextEditor = -> conversationPageState = READ_POSTS
+    $scope.cancelPostClicked = -> closeTextEditor()
+    $scope.escapeTextEditor = -> closeTextEditor()
     $scope.submitPostText = -> if postSubmissionInProgress then "Sending..." else "Submit"
     $scope.authorDisplayNameForPost = (id) ->
         if postsById[id].type is "resolution"
@@ -106,10 +107,13 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
         $scope.postSubmitError = ""
         postSubmissionInProgress = true
         if conversationPageState is EDIT_SUMMARY
+            ConversationService.updateSummaryText(conversationId, "")
             API.editSummaryByConversationId(conversationId, $scope.editPostText).success (response) -> handlePostEditResponse(response, false)
         else if conversationPageState is EDIT_RESOLUTION
+            ConversationService.updateResolutionText(conversationId, "")
             API.editResolutionByConversationId(conversationId, $scope.editPostText).success (response) -> handlePostEditResponse(response, false)
         else if currentPostEditId is null
+            ConversationService.updateAddPostText(conversationId, "")
             API.createPostByConversationId(conversationId, $scope.editPostText).success (response) -> handlePostEditResponse(response, true)
         else
             API.editPostById(currentPostEditId, $scope.editPostText).success (response) -> handlePostEditResponse(response, false)
@@ -121,6 +125,7 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
 
     $scope.shouldDisplayPostEdit = (id) -> postsById[id].author.id == AppState.user.id and postsById[id].type is "post"
     $scope.editPostClicked = (id) ->
+        savePostInProgress()
         currentPostEditId = id
         $scope.editPostText = postsById[id].text
         expandEditorViewForState(EDIT_OR_ADD_POST)
@@ -130,7 +135,8 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
     $scope.postEditorWidthClass = -> if conversationPageState isnt EDIT_SUMMARY then "post-editor-full" else "post-editor-half"
     $scope.shouldDisableProposeSummary = -> conversationPageState is EDIT_SUMMARY
     $scope.proposeSummaryClicked = ->
-        $scope.editPostText = if conversation.pendingSummaries then conversation.pendingSummaries.opposing else ""
+        savePostInProgress()
+        $scope.editPostText = if conversation.pendingSummaries && conversation.pendingSummaries.opposing != "" then conversation.pendingSummaries.opposing else ConversationService.getSummaryText(conversationId)
         expandEditorViewForState(EDIT_SUMMARY)
 
     $scope.ownPendingSummaryText = -> if conversation.pendingSummaries then conversation.pendingSummaries.own else ""
@@ -165,13 +171,24 @@ conversation.controller("ConversationController", ["$scope", "$stateParams", "AP
     $scope.shouldDisableApproveResolution = -> !conversation.resolution or conversation.resolution.state != "in_progress" or conversation.resolution.updated_by_id is AppState.user.id
     $scope.showApproveResolution = -> conversationPageState is EDIT_RESOLUTION
     $scope.editResolutionClicked = ->
-        $scope.editPostText = if conversation.resolution then conversation.resolution.text else ""
+        savePostInProgress()
+        $scope.editPostText = if conversation.resolution && conversation.resolution.text != "" then conversation.resolution.text else ConversationService.getResolutionText(conversationId)
         expandEditorViewForState(EDIT_RESOLUTION)
 
-    # Handle editor switching state, ex. writing a new post and switching (before submitting) to editing an old post
-    handleEditorStateChange = (state) ->
-        # TODO: implement this
-        return
+    savePostInProgress = () ->
+        if conversationPageState == EDIT_OR_ADD_POST && currentPostEditId == null
+            # User was writing a new post
+            ConversationService.updateAddPostText(conversationId, $scope.editPostText)
+        else if conversationPageState == EDIT_SUMMARY
+            # User was writing a summary
+            ConversationService.updateSummaryText(conversationId, $scope.editPostText)
+        else if conversationPageState == EDIT_RESOLUTION
+            # User was writing the resolution
+            ConversationService.updateResolutionText(conversationId, $scope.editPostText)
+
+    closeTextEditor = () ->
+        savePostInProgress()
+        conversationPageState = READ_POSTS
 
     expandEditorViewForState = (state) ->
         if conversationPageState is READ_POSTS and state isnt READ_POSTS
@@ -250,6 +267,7 @@ conversation.service("ConversationService", () ->
             c = {addPostText: "", summaryText: "", resolutionText: ""}
             conversations[conversationId] = c
             return c
+    # getter and setter for posts in progress
     this.updateAddPostText = (conversationId, text) ->
         getConversation(conversationId).addPostText = text
     this.updateSummaryText = (conversationId, text) ->
@@ -262,5 +280,8 @@ conversation.service("ConversationService", () ->
         return getConversation(conversationId).summaryText
     this.getResolutionText = (conversationId) ->
         return getConversation(conversationId).resolutionText
+    this.hasUnsavedProgress = (conversationId) ->
+        c = getConversation(conversationId)
+        return (c.addPostText || c.summaryText || c.resolutionText)
     return
 )

--- a/features/conversation.feature
+++ b/features/conversation.feature
@@ -80,3 +80,25 @@ Scenario: the user can approve a resolution
     Then I should not see "post-textarea"
     And I wait 1 second
     And I should see "Here is my resolution"
+
+Scenario: Posts in progress should not disappear after switching to other editors
+    Given I am on the conversation page for "What messages are you posting?"
+    And I click "Add a post" in the conversation page
+    And I wait 1 second
+    When I fill in "post-textarea" with "Writing a new post"
+    And I click "Propose a summary" in the conversation page
+    And I wait 1 second
+    And I fill in "post-textarea" with "Writing a summary"
+    And I click "Edit resolution" in the conversation page
+    And I wait 1 second
+    And I fill in "post-textarea" with "Writing a resolution"
+    When I click "Add a post" in the conversation page
+    And I wait 1 second
+    Then I should see the editor filled with "Writing a new post"
+    When I click "Propose a summary" in the conversation page
+    And I wait 1 second
+    Then I should see the editor filled with "Writing a summary"
+    When I click "Edit resolution" in the conversation page
+    And I wait 1 second
+    Then I should see the editor filled with "Writing a resolution"
+

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -53,3 +53,11 @@ When /^I click "(.*)" in the conversation page$/ do |element_name|
     else raise "No check for clicking the #{element_name} element in the conversation page."
     end
 end
+
+Then /I(?: should)?( not)? see the editor filled with "(.*)"/ do |should_not_see, content|
+    if should_not_see
+        expect(page.find("[name=post-textarea]").value).not_to eq(content)
+    else
+        expect(page.find("[name=post-textarea]").value).to eq(content)
+    end
+end

--- a/public/landingPage.html
+++ b/public/landingPage.html
@@ -15,30 +15,12 @@
                 <p id="tag">
                     Engage in constructive and open discourse about political
                     topics that are important to you.
-<<<<<<< HEAD
                 </p>
                 <p>
                     In exchange for deliberative listening, see the world from
                     someone else's perspective, and in return, expose someone to
                     your own.  You may even learn something new about your own
                     world views!
-=======
-                    <!--
-                    Politics is a complicated topic. People have disagreements
-                    and it's hard to agree on something. But what if you could
-                    talk about it? To be able to discuss differences with
-                    someone of opposing opinion?
-                    -->
-                </p>
-                <p>
-                    In exchange for deliberative listening, see the world from
-                    someone else's perspective, and in return, expose them to
-                    your own.  You may even learn something new about your own
-                    world views!
-                    <!--
-                    Find people of other perspectives and learn something new.
-                    -->
->>>>>>> Landing page overhaul
                 </p>
                 <p>
                     Click the button below to get started.  We'll ask you to

--- a/public/landingPage.html
+++ b/public/landingPage.html
@@ -15,12 +15,30 @@
                 <p id="tag">
                     Engage in constructive and open discourse about political
                     topics that are important to you.
+<<<<<<< HEAD
                 </p>
                 <p>
                     In exchange for deliberative listening, see the world from
                     someone else's perspective, and in return, expose someone to
                     your own.  You may even learn something new about your own
                     world views!
+=======
+                    <!--
+                    Politics is a complicated topic. People have disagreements
+                    and it's hard to agree on something. But what if you could
+                    talk about it? To be able to discuss differences with
+                    someone of opposing opinion?
+                    -->
+                </p>
+                <p>
+                    In exchange for deliberative listening, see the world from
+                    someone else's perspective, and in return, expose them to
+                    your own.  You may even learn something new about your own
+                    world views!
+                    <!--
+                    Find people of other perspectives and learn something new.
+                    -->
+>>>>>>> Landing page overhaul
                 </p>
                 <p>
                     Click the button below to get started.  We'll ask you to


### PR DESCRIPTION
Any posts in progress in a conversation (new post, summary, resolution that user haven't submitted) are now saved as long as user doesn't leave the site.

TODO:
Warn user when they try to leave the site when they have unsubmitted posts in progress.
